### PR TITLE
There is a bug in the Confluence {code} tag when exporting to PDF.

### DIFF
--- a/rst2confluence/confluence.py
+++ b/rst2confluence/confluence.py
@@ -181,13 +181,13 @@ class ConfluenceTranslator(nodes.NodeVisitor):
 
     def visit_literal_block(self, node):
         self.keepLineBreaks = True
-        self._add('{code}')
+        self._add('{noformat}')
         self._newline()
 
     def depart_literal_block(self, node):
         self.keepLineBreaks = False
         self._newline()
-        self._add('{code}')
+        self._add('{noformat}')
         self._newline()
 
     def visit_literal(self, node):


### PR DESCRIPTION
When Confluence exports documents with the {code} tag to PDF, the contents of the {code} tag are omitted.

Using the {noformat} tag instead provides similar benefits and allows
successful export to PDF.
